### PR TITLE
Trigger Guide Converter only on changes to guide material

### DIFF
--- a/.github/workflows/TriggerQuickLabs.yaml
+++ b/.github/workflows/TriggerQuickLabs.yaml
@@ -5,8 +5,13 @@ name: action
 on:
   push:
     branches:
-    - sn-automation-testing-master
-    - sn-automation-testing-qa
+      - 'sn-automation-testing-master'
+      - 'sn-automation-testing-qa'
+    paths:
+      - 'README.adoc'
+      - 'start/**'
+      - 'finish/**'
+      - 'assets/**'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
Avoids pushing empty commits to the `quick-labs' repository by only running when changes are made to the guide and associated material.

This PR updates the QA branch.

Signed-off-by: Austin Bailey Austin.Bailey@ibm.com